### PR TITLE
migrs/key mapping override and NSDate

### DIFF
--- a/PAPreferences/PAPreferences.h
+++ b/PAPreferences/PAPreferences.h
@@ -17,6 +17,6 @@ extern NSString * const PAPreferencesDidChangeNotification;
 + (instancetype)sharedInstance;
 
 - (BOOL)synchronize;
-+ (NSString *)transformKey:(NSString *)key;
++ (NSString *)defaultsKeyForPropertyName:(NSString *)key;
 
 @end

--- a/PAPreferences/PAPreferences.m
+++ b/PAPreferences/PAPreferences.m
@@ -134,7 +134,7 @@ NSDate *paprefDateGetter(id self, SEL _cmd) {
     return _sharedInstance;
 }
 
-+ (NSString *)transformKey:(NSString *)key {
++ (NSString *)defaultsKeyForPropertyName:(NSString *)key {
     return key;
 }
 
@@ -172,9 +172,9 @@ NSDate *paprefDateGetter(id self, SEL _cmd) {
                     NSLog(@"Retained properties are not supported by PAPreferences, use assign instead");
                 } else {
                     if ([self isValidType:type]) {
-                        name = [[self class] transformKey:name];
-                        _dynamicProperties[getterName] = [[PAPropertyDescriptor alloc] initWithName:name type:type isSetter:NO];
-                        _dynamicProperties[setterName] = [[PAPropertyDescriptor alloc] initWithName:name type:type isSetter:YES];
+                        NSString *defaultsKey = [[self class] defaultsKeyForPropertyName:name];
+                        _dynamicProperties[getterName] = [[PAPropertyDescriptor alloc] initWithName:defaultsKey type:type isSetter:NO];
+                        _dynamicProperties[setterName] = [[PAPropertyDescriptor alloc] initWithName:defaultsKey type:type isSetter:YES];
                     } else {
                         NSLog(@"Type of %@ is not supported by PAPreferences", name);
                     }

--- a/PAPreferencesTests/PAPreferencesTests.m
+++ b/PAPreferencesTests/PAPreferencesTests.m
@@ -49,11 +49,11 @@ NSString * const RemappedTitleKey = @"KEY_TITLE";
     return self.username;
 }
 
-+ (NSString *)transformKey:(NSString *)key {
-    if ([key isEqualToString:@"title"]) {
++ (NSString *)defaultsKeyForPropertyName:(NSString *)name {
+    if ([name isEqualToString:@"title"]) {
         return RemappedTitleKey;
     }
-    return key;
+    return name;
 }
 
 @end
@@ -175,13 +175,13 @@ NSString * const RemappedTitleKey = @"KEY_TITLE";
     XCTAssertEqualObjects([[NSUserDefaults standardUserDefaults] objectForKey:@"username"], @"alice");
 }
 
-- (void)testTransformKeyPersistencd {
+- (void)testDefaultsKeyForPropertyNamePersistence {
     MyPreferences *prefs = [MyPreferences sharedInstance];
     prefs.title = @"yesterday";
     XCTAssertEqualObjects([[NSUserDefaults standardUserDefaults] objectForKey:RemappedTitleKey], @"yesterday");
 }
 
-- (void)testTransformKeyRetrieval {
+- (void)testDefaultsKeyForPropertyNameRetrieval {
     MyPreferences *prefs = [MyPreferences sharedInstance];
     [[NSUserDefaults standardUserDefaults] setObject:@"yesterday" forKey:RemappedTitleKey];
     XCTAssertEqualObjects(prefs.title, @"yesterday");


### PR DESCRIPTION
This is work by @migrs.

I liked the idea for the -transformKey: override point, but I didn’t like the message signature. So I renamed it to “-defaultsKeyForPropertyName:”, which should be closer to what it does. 

NSDate support is good to have.
