### PR TITLE
Add Copy to prevent release immediately when open code optimization

### DIFF
--- a/PAPreferences/PAPreferences.m
+++ b/PAPreferences/PAPreferences.m
@@ -189,7 +189,7 @@ void paprefCodableObjectSetter(id self, SEL _cmd, id value) {
         for (int i=0; i<cProps; i++) {
             objc_property_t property = properties[i];
             NSString *name = [NSString stringWithUTF8String:property_getName(property)];
-            NSString *getterName = name;
+            NSString *getterName = [name copy];
             NSString *setterName = [NSString stringWithFormat:@"set%@%@:", [[name substringToIndex:1] capitalizedString], [name substringFromIndex:1]];
             NSString *type = nil;
             BOOL isDynamic = NO;


### PR DESCRIPTION
When Xcode project set Code Generation Optimization Level and also the user defines a custom getter selector name for the PAPreferences subclass's property, it will crash!!! Because when the gettername was reassigned a new value , the name will release immediately for code optimize.