### PR TITLE
PAPreferences will now emit KVO notifications for its properties when th...

### DIFF
--- a/PAPreferences/PAPreferences.m
+++ b/PAPreferences/PAPreferences.m
@@ -179,6 +179,19 @@ void paprefCodableObjectSetter(id self, SEL _cmd, id value) {
     return key;
 }
 
+// Cause KVO notifications to be emitted even when the corresponding
+// value for key is set in NSUserDefaults directly.
++ (NSSet *)keyPathsForValuesAffectingValueForKey:(NSString *)key
+{
+	NSSet *result = [super keyPathsForValuesAffectingValueForKey:key];
+	
+	PAPropertyDescriptor *propertyDescriptor = _dynamicProperties[key];
+	NSString *defaultsKey = [self defaultsKeyForPropertyName:key];
+	if (!propertyDescriptor || !defaultsKey) return result;
+	
+	NSString *keyPath = [NSString stringWithFormat:@"userDefaults.%@", defaultsKey];
+	return [result setByAddingObject:keyPath];
+}
 
 - (instancetype)init {
     if (self = [super init]) {


### PR DESCRIPTION
...eir underlying NSUserDefault is changed directly.

This makes it possible to bind UI to PAPreferences using Cocoa Bindings and have the bound UI automatically update when the corresponding key/value pair in NSUserDefaults is changed directly. Enables the same sort of usage in this way as binding to NSUserDefaultsController does.
