### PR TITLE
Add the defaults keys to the change notification

### DIFF
--- a/PAPreferences/PAPreferences.h
+++ b/PAPreferences/PAPreferences.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * const PAPreferencesDidChangeNotification;
+extern NSString * const PAPreferencesChangedPropertyKey;
 
 @interface PAPreferences : NSObject {
     NSDictionary *_properties;

--- a/PAPreferences/PAPreferences.m
+++ b/PAPreferences/PAPreferences.m
@@ -11,6 +11,7 @@
 #include <objc/runtime.h>
 
 NSString * const PAPreferencesDidChangeNotification = @"PAPreferencesDidChangeNotification";
+NSString * const PAPreferencesChangedPropertyKey = @"PAPreferencesChangedPropertyKey";
 
 static NSMutableDictionary *_dynamicProperties;
 
@@ -40,7 +41,8 @@ void paprefBoolSetter(id self, SEL _cmd, BOOL value) {
     if ([self shouldAutomaticallySynchronize]) {
         [self synchronize];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self];
+    NSDictionary *userInfo = @{PAPreferencesChangedPropertyKey: defaultsKey};
+    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self userInfo:userInfo];
 }
 
 double paprefDoubleGetter(id self, SEL _cmd) {
@@ -54,7 +56,8 @@ void paprefDoubleSetter(id self, SEL _cmd, double value) {
     if ([self shouldAutomaticallySynchronize]) {
         [self synchronize];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self];
+    NSDictionary *userInfo = @{PAPreferencesChangedPropertyKey: defaultsKey};
+    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self userInfo:userInfo];
 }
 
 float paprefFloatGetter(id self, SEL _cmd) {
@@ -68,7 +71,8 @@ void paprefFloatSetter(id self, SEL _cmd, float value) {
     if ([self shouldAutomaticallySynchronize]) {
         [self synchronize];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self];
+    NSDictionary *userInfo = @{PAPreferencesChangedPropertyKey: defaultsKey};
+    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self userInfo:userInfo];
 }
 
 NSInteger paprefIntegerGetter(id self, SEL _cmd) {
@@ -82,7 +86,8 @@ void paprefIntegerSetter(id self, SEL _cmd, NSInteger value) {
     if ([self shouldAutomaticallySynchronize]) {
         [self synchronize];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self];
+    NSDictionary *userInfo = @{PAPreferencesChangedPropertyKey: defaultsKey};
+    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self userInfo:userInfo];
 }
 
 id paprefObjectGetter(id self, SEL _cmd) {
@@ -105,7 +110,8 @@ void paprefObjectSetter(id self, SEL _cmd, id value) {
     if ([self shouldAutomaticallySynchronize]) {
         [self synchronize];
     }
-    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self];
+    NSDictionary *userInfo = @{PAPreferencesChangedPropertyKey: defaultsKey};
+    [[NSNotificationCenter defaultCenter] postNotificationName:PAPreferencesDidChangeNotification object:self userInfo:userInfo];
 }
 
 NSURL *paprefURLGetter(id self, SEL _cmd) {

--- a/PAPreferencesTests/PAPreferencesTests.m
+++ b/PAPreferencesTests/PAPreferencesTests.m
@@ -64,6 +64,7 @@ NSString * const RemappedTitleKey = @"KEY_TITLE";
 
 @interface PAPreferencesTests : XCTestCase {
     BOOL _seenNotification;
+    NSString *_notificationChangedProperty;
 }
 
 @end
@@ -299,6 +300,15 @@ NSString * const RemappedTitleKey = @"KEY_TITLE";
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
+- (void)testNotificationUserInfo {
+    _notificationChangedProperty = nil;
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleNotification:) name:PAPreferencesDidChangeNotification object:nil];
+    MyPreferences *prefs = [MyPreferences sharedInstance];
+    prefs.username = @"jack";
+    XCTAssertTrue([_notificationChangedProperty isEqualToString:@"username"]);
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
 - (void)testAutoSynchronizeDefaultsOn {
     MyPreferences *prefs = [MyPreferences sharedInstance];
     XCTAssertTrue(prefs.shouldAutomaticallySynchronize);
@@ -306,6 +316,7 @@ NSString * const RemappedTitleKey = @"KEY_TITLE";
 
 - (void)handleNotification:(NSNotification *)notification {
     _seenNotification = YES;
+    _notificationChangedProperty = notification.userInfo[PAPreferencesChangedPropertyKey];
 }
 
 #if DEBUG


### PR DESCRIPTION
This adds the defaults keys to the userInfo property on the NSNotification that is delivered when a preference is changed. This allows changed properties to be identified by the reciever of a notification.